### PR TITLE
SD-1594 Create CI/CD jobs for influxdb-client to upload artifact to CodeArtifactory

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
               sh(label: 'maven set version',
                 script: "./mvnw versions:set -DnewVersion=${BUILD_VERSION} -DprocessAllModules -DgenerateBackupPoms=false")
               sh(label: 'maven package',
-                script: "./mvnw clean package")
+                script: "./mvnw clean package -DskipTests")
               sh(label: "maven publish",
                 script: "./mvnw clean deploy -s settings.xml -DskipTests")
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,74 @@
+pipeline {
+  options {
+    buildDiscarder logRotator(artifactDaysToKeepStr: '1', artifactNumToKeepStr: '60', daysToKeepStr: '60', numToKeepStr: '60')
+    ansiColor('xterm')
+    timestamps()
+    withCredentials([[$class       : 'AmazonWebServicesCredentialsBinding',
+                      credentialsId: 'in-a-p-jen-codeartifact']])
+  }
+  
+  environment {
+    REGION = 'us-east-1'
+    DOMAIN = "spanning"
+    REPOSITORY_NAME = "test"
+    REPOSITORY_FORMAT = "maven"
+    BUILD_IMAGE = 'maven:3.6.3-openjdk-11'
+    TIMESTAMP = (new Date()).format('yyyyMMdd-HHmm')
+  }
+  
+  agent {
+    label 'build'
+  }
+  
+  stages {
+    stage('Build') {
+      environment {
+        CODE_ARTIFACT_AUTH_TOKEN = sh(returnStdout: true,
+          label: 'Get CodeArtifact auth token',
+          script: '''#!/bin/bash
+                                                 aws codeartifact get-authorization-token \
+                                                    --region $REGION \
+                                                    --domain $DOMAIN \
+                                                    --query authorizationToken \
+                                                    --output text \
+                                                    --duration-seconds 900''').trim()
+        CODE_ARTIFACT_URL = sh(returnStdout: true,
+          label: 'Get CodeArtifact URL',
+          script: '''#!/bin/bash
+                                          aws codeartifact get-repository-endpoint \
+                                            --region $REGION \
+                                            --domain $DOMAIN \
+                                            --repository $REPOSITORY_NAME \
+                                            --format $REPOSITORY_FORMAT \
+                                            --output text''').trim()
+        BUILD_VERSION = "${TIMESTAMP}.${GIT_COMMIT.substring(0, 9)}.${BUILD_NUMBER}"
+      }
+      steps {
+        writeFile(file: 'settings.xml',
+          text: """
+                          <settings>
+                            <servers>
+                              <server>
+                                <id>codeartifact</id>
+                                <username>aws</username>
+                                <password>${CODE_ARTIFACT_AUTH_TOKEN}</password>
+                              </server>
+                            </servers>
+                          </settings>
+                        """)
+        withDockerContainer(image: BUILD_IMAGE) {
+          withMaven(mavenOpts: '-XX:+UseParallelGC') {
+            withEnv(["PATH=${MVN_CMD_DIR}:${PATH}"]) {
+              sh(label: 'maven set version',
+                script: "mvn versions:set -DnewVersion=${BUILD_VERSION} -DprocessAllModules -DgenerateBackupPoms=false")
+              sh(label: 'maven build',
+                script: "mvn clean package -DskipTests=true -DskipStaticAnalyse=true")
+              sh(label: "maven publish",
+                script: "mvn clean deploy -s settings.xml -DskipTests=true -DskipStaticAnalyse=true")
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,10 +61,10 @@ pipeline {
             withEnv(["PATH=${MVN_CMD_DIR}:${PATH}"]) {
               sh(label: 'maven set version',
                 script: "./mvnw versions:set -DnewVersion=${BUILD_VERSION} -DprocessAllModules -DgenerateBackupPoms=false")
-              sh(label: 'maven build',
+              sh(label: 'maven package',
                 script: "./mvnw clean package")
               sh(label: "maven publish",
-                script: "./mvnw clean deploy -s settings.xml")
+                script: "./mvnw clean deploy -s settings.xml -DskipTests")
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
   environment {
     REGION = 'us-east-1'
     DOMAIN = "spanning"
-    REPOSITORY_NAME = "test"
+    REPOSITORY_NAME = "shared"
     REPOSITORY_FORMAT = "maven"
     BUILD_IMAGE = 'maven:3.6.3-openjdk-11'
     TIMESTAMP = (new Date()).format('yyyyMMdd-HHmm')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,21 +26,21 @@ pipeline {
         CODE_ARTIFACT_AUTH_TOKEN = sh(returnStdout: true,
           label: 'Get CodeArtifact auth token',
           script: '''#!/bin/bash
-                                                 aws codeartifact get-authorization-token \
-                                                    --region $REGION \
-                                                    --domain $DOMAIN \
-                                                    --query authorizationToken \
-                                                    --output text \
-                                                    --duration-seconds 900''').trim()
+                     aws codeartifact get-authorization-token \
+                        --region $REGION \
+                        --domain $DOMAIN \
+                        --query authorizationToken \
+                        --output text \
+                        --duration-seconds 900''').trim()
         CODE_ARTIFACT_URL = sh(returnStdout: true,
           label: 'Get CodeArtifact URL',
           script: '''#!/bin/bash
-                                          aws codeartifact get-repository-endpoint \
-                                            --region $REGION \
-                                            --domain $DOMAIN \
-                                            --repository $REPOSITORY_NAME \
-                                            --format $REPOSITORY_FORMAT \
-                                            --output text''').trim()
+                     aws codeartifact get-repository-endpoint \
+                       --region $REGION \
+                       --domain $DOMAIN \
+                       --repository $REPOSITORY_NAME \
+                       --format $REPOSITORY_FORMAT \
+                       --output text''').trim()
         BUILD_VERSION = "${TIMESTAMP}.${GIT_COMMIT.substring(0, 9)}.${BUILD_NUMBER}"
       }
       steps {
@@ -60,11 +60,11 @@ pipeline {
           withMaven(mavenOpts: '-XX:+UseParallelGC') {
             withEnv(["PATH=${MVN_CMD_DIR}:${PATH}"]) {
               sh(label: 'maven set version',
-                script: "mvn versions:set -DnewVersion=${BUILD_VERSION} -DprocessAllModules -DgenerateBackupPoms=false")
+                script: "./mvnw versions:set -DnewVersion=${BUILD_VERSION} -DprocessAllModules -DgenerateBackupPoms=false")
               sh(label: 'maven build',
-                script: "mvn clean package -DskipTests=true -DskipStaticAnalyse=true")
+                script: "./mvnw clean package")
               sh(label: "maven publish",
-                script: "mvn clean deploy -s settings.xml -DskipTests=true -DskipStaticAnalyse=true")
+                script: "./mvnw clean deploy -s settings.xml")
             }
           }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,14 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
+    <distributionManagement>
+        <repository>
+            <id>codeartifact</id>
+            <name>codeartifact</name>
+            <url>${env.CODE_ARTIFACT_URL}</url>
+        </repository>
+    </distributionManagement>
+
     <dependencies>
         <dependency>
             <groupId>com.squareup.okhttp</groupId>


### PR DESCRIPTION
## Description
Ticket: https://kaseya.atlassian.net/browse/SD-1594
### Why?
We want to use AWS CodeArtifactory as artifact repository manager for our maven packages
### What's Changing?
Add Jenkinsfile to build and push influxdb-client artifact to AWS Codeartifact
## Products affected
* [ ] Burn
* [ ] Rash
* [ ] Scar
* [ ] Scum
* [x] Stab
* [ ] Wrap 
* [ ] Eleon 
* [ ] Infrastructure
## Demo
![image](https://user-images.githubusercontent.com/8866466/114686901-e06f4b00-9d1b-11eb-9a9e-497e7b2bbfd3.png)
![image](https://user-images.githubusercontent.com/8866466/114686982-f54bde80-9d1b-11eb-841c-487503f47807.png)


## Deploying
List any additional steps needed to accompany this PR, such as deleting data bag items or roles.
* 
## Testing in Stage
How can this PR be tested in Stage?
* 
## Verifying in Production
How will you verify this in Production?
* 